### PR TITLE
Do not include the hidden properties

### DIFF
--- a/lib/typedefs.js
+++ b/lib/typedefs.js
@@ -87,8 +87,9 @@ function generateRelations(relations) {
         .join(' ');
 }
 
-function generateOutputProps(props) {
-    return _.map(props, prop => {
+function generateOutputProps(props, hiddenProps) {
+    let visibleProps = _.filter(props, prop => hiddenProps.indexOf(prop.name) === -1);
+    return _.map(visibleProps, prop => {
         return `${prop.name}: ${prop.value}${prop.required ? '!' : ''} `;
     }).join('');
 }
@@ -109,7 +110,7 @@ function generateModels(models) {
         let definitions = generateDefinitions(model.modelName, model.definition.properties);
         let rels = generateRelations(model.relations);
 
-        let outputProps = generateOutputProps(definitions.props);
+        let outputProps = generateOutputProps(definitions.props, model.definition.settings.hidden);
         let inputProps = generateInputProps(definitions.props);
 
         let types = _.map(definitions.types, t => {
@@ -119,7 +120,7 @@ function generateModels(models) {
 
         let outputModel = `type ${model.modelName} {
             ${outputProps}
-            ${rels}    
+            ${rels}
         }`;
         console.log('OUTPUT MODEL', outputModel);
 
@@ -128,10 +129,10 @@ function generateModels(models) {
         }`;
         console.log('INPUT MODEL', inputModel);
 
-        return ` 
-            ${types} 
-            ${outputModel} 
-            ${inputModel} 
+        return `
+            ${types}
+            ${outputModel}
+            ${inputModel}
         `;
     }).join(' ');
 }
@@ -139,7 +140,7 @@ function generateModels(models) {
 function generateRootQueries(models) {
     return _.map(helper.sharedModels(models), model => {
         return `
-                ${model.modelName} (id: ID!): ${model.modelName} 
+                ${model.modelName} (id: ID!): ${model.modelName}
                 ${model.pluralModelName} ${pagination}: [${model.modelName}]
             `;
     }).join(' ');
@@ -201,16 +202,16 @@ function generateMethods(models) {
  */
 function generateTypeDefs(models) {
     return [
-        `scalar Date 
+        `scalar Date
         scalar JSON `,
         generateModels(models),
-        `type Query { 
-            ${generateRootQueries(models)} 
+        `type Query {
+            ${generateRootQueries(models)}
         }`,
-        `type Mutation { 
+        `type Mutation {
             ${generateSaves(models)}
-            ${generateDeletes(models)} 
-            ${generateMethods(models)}   
+            ${generateDeletes(models)}
+            ${generateMethods(models)}
          }`,
         `schema {
             query: Query


### PR DESCRIPTION
There are cases when you can have hidden properties
in a model (like the password field).

These properties shouldn't be exposed in graphql.
